### PR TITLE
Fix access to undefined response

### DIFF
--- a/lib/PushInitiator.js
+++ b/lib/PushInitiator.js
@@ -67,7 +67,7 @@ PushInititator.prototype.push = function(message, callback) {
             'Content-length': Buffer.byteLength(body, 'utf8'),
             'Authorization': 'Basic ' + this.authToken
         }
-	}
+	};
 	
 	var result = { };
 	var err = undefined;
@@ -111,26 +111,29 @@ PushInititator.prototype.push = function(message, callback) {
 
             if (callback)
                 callback(err);
-        }).on('data', function(data) {
-        	xml2js.parseString(data, function(err, res) {
-        		if(res.pap !== undefined) {
-        			if(res.pap['push-response'] === undefined) {
-	        			var response = res.pap['badmessage-response'][0].$;
-	        			
-	        			console.log(response);
-	        		}
-	        		else {        		
-		        		var response = res.pap['push-response'][0];
-		   				response = response['response-result'][0].$	        
-		   			}
-		   			
-	        		result.statusCode = response.code;
-	        		result.message = response.desc;
-	        		
-	        		callback(undefined, result);
-        		}
-        	});
-        });
+		}).on('data', function(data) {
+			xml2js.parseString(data, function(err, res) {
+				if(res && res.pap !== undefined) {
+					var response;
+					if(res.pap['push-response'] === undefined) {
+						response = res.pap['badmessage-response'][0].$;
+
+						console.log(response);
+					}
+					else {
+						response = res.pap['push-response'][0];
+						response = response['response-result'][0].$;
+					}
+
+					result.statusCode = response.code;
+					result.message = response.desc;
+
+					callback(undefined, result);
+				} else {
+					callback(err);
+				}
+			});
+		});
 	});
 	
 	req.write(body);


### PR DESCRIPTION
Previous code caused TypeError: Cannot read property 'pap' of undefined in case of errors.

See https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/lib/xml2js.js#L400 for reference.

Here is the excerpt from our log which lead me to looking into this:

```
/opt/node_modules/node-bb10/lib/PushInitiator.js:116
                        if(res.pap !== undefined) {
                              ^
TypeError: Cannot read property 'pap' of undefined
    at /opt/node_modules/node-bb10/lib/PushInitiator.js:116:17
    at Parser.<anonymous> (/opt/node_modules/node-bb10/node_modules/xml2js/lib/xml2js.js:265:20)
    at Parser.emit (events.js:95:17)
```
