### PR TITLE
Use 24-hour format.

### DIFF
--- a/lib/PushInitiator.js
+++ b/lib/PushInitiator.js
@@ -45,7 +45,7 @@ PushInititator.prototype.push = function(message, callback) {
     var body = message.toPAPMessage({
         'push-id': message.id,
         'source-reference': this.applicationId,
-        'deliver-before-timestamp': deliverBefore.format('YYYY-MM-DDThh:mm:ss[Z]')
+        'deliver-before-timestamp': deliverBefore.format('YYYY-MM-DDTHH:mm:ss[Z]')
     });
 
     var host = 'cp' + this.contentProviderId + '.' + Constants.PRODUCTION_URL;


### PR DESCRIPTION
12-hour format causes invalid timestamps to be inserted and can cause "deliver-before-timestamp has already expired"
